### PR TITLE
Fix type error introduced by TS 4.3 and above

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, latest]
+        node-version: [14.x, 16.x]
         ts-version: [4.3, 4.4, 4.5, 4.x]
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
-        ts-version: [3.x, 4.x, latest]
+        node-version: [14.x, 16.x, latest]
+        ts-version: [4.3, 4.4, 4.5, 4.x]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/index.ts
+++ b/index.ts
@@ -92,8 +92,6 @@ export namespace t {
         default?: any[];
     }
 
-    interface GenericArrayType extends ArrayType<Schema> {}
-
     export interface TupleType<T extends Schema[]> extends BaseType {
         type: 'array';
         // Omitting this keyword has the same behavior as an empty schema.
@@ -108,25 +106,17 @@ export namespace t {
         default?: any[];
     }
 
-    interface GenericTupleType extends TupleType<Schema[]> {}
-
     export interface AnyOfType<T extends Schema[]> extends BaseType {
         anyOf: T;
     }
-
-    interface GenericAnyOfType extends AnyOfType<Schema[]> {}
 
     export interface OneOfType<T extends Schema[]> extends BaseType {
         oneOf: T;
     }
 
-    interface GenericOneOfType extends OneOfType<Schema[]> {}
-
     export interface AllOfType<T extends Schema[]> extends BaseType {
         allOf: T;
     }
-
-    interface GenericAllOfType extends OneOfType<Schema[]> {}
 
     export type ObjectProperties = {[key: string]: Schema}
 
@@ -137,20 +127,19 @@ export namespace t {
         maxProperties?: number;
         minProperties?: number;
         // Omitting this keyword has the same behavior as an empty array.
-        required?: Array<keyof T>;
+
+        // This is broken in TS 4.3 and above ;(
+        // required?: Array<keyof T>;
+        required?: string[];
         additionalProperties?: AdditionalProperties;
         // FIXME: dependencies?: {};
         propertyNames?: Schema;
         default?: object;
     }
 
-    interface GenericObjectType extends ObjectType<ObjectProperties> {};
-
     export interface RefType<T extends Schema> extends BaseType {
         $ref: string;
     }
-
-    interface GenericRefType extends RefType<Schema> {};
 
     export type Schema = boolean
         | StringType
@@ -158,13 +147,13 @@ export namespace t {
         | IntegerType
         | BooleanType
         | NullType
-        | GenericAnyOfType
-        | GenericOneOfType
-        | GenericAllOfType
-        | GenericArrayType
-        | GenericTupleType
-        | GenericObjectType
-        | GenericRefType;
+        | AnyOfType<Schema[]>
+        | OneOfType<Schema[]>
+        | OneOfType<Schema[]>
+        | ArrayType<Schema>
+        | TupleType<Schema[]>
+        | ObjectType<ObjectProperties>
+        | RefType<Schema>;
 
     export interface ArrayTSType<U extends Schema> extends Array<TSType<U>> {}
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
   "author": "Tao Peng",
   "license": "MIT",
   "devDependencies": {
-    "typescript": "^4.1.3"
+    "typescript": ">=4.3"
   }
 }

--- a/test.ts
+++ b/test.ts
@@ -174,7 +174,7 @@ namespace meta {
         s.integer(),
         s.boolean(),
         // FIXME: s.object() doesn't work
-        // s.object(),
+        s.object({"properties": {}}),
         s.object({
             'properties': {
                 'hello': s.string()
@@ -192,7 +192,7 @@ namespace meta {
         2,
         2,
         true,
-        // {},
+        {},
         {'hello': 'haha'},
         ['asas', 1, true, false, {}],
     ]);


### PR DESCRIPTION
Upgraded to TS 4.3 introduced the following compelling error:

```typescript
import {t, s} from './index';
const yy = s.object({"properties": {"hello": s.string()}});
const xx: t.ObjectType<t.ObjectProperties> = yy;
```

```
hello.ts:3:7 - error TS2322: Type 'ObjectType<{ hello: StringType<string>; }, Schema>' is not assignable to type 'ObjectType<ObjectProperties, Schema>'.
  Property '"hello"' is missing in type 'ObjectProperties' but required in type '{ hello: t.StringType<string>; }'.

71 const xx: t.ObjectType<t.ObjectProperties> = yy;﻿
```

It was because `required: Array<keyof T>` for unknown reason. Relaxing the type constraint to `required: string[]` fixed the issue.
